### PR TITLE
Refactor: Make repository path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ This project provides an MCP (Model Context Protocol) server for the [`backlog.m
 }
 ```
 
+## Configuration
+
+The server can be configured using the following environment variable:
+
+- `BACKLOG_REPO_PATH`: The absolute path to the repository where the `backlog` directory is located. If not set, it defaults to the current working directory.
+
 ## Usage
 
 ### Testing
@@ -55,9 +61,9 @@ npm run inspector
 
 This project uses GitHub Actions to automate the build, test, and release process.
 
--   **Build and Test:** On every push or pull request to the `main` and `develop` branches, the workflow in `.github/workflows/build.yml` is triggered. It installs dependencies, lints the code, builds the project, and runs the tests.
--   **Pull Request Creation:** If a build on the `develop` branch is successful, a pull request is automatically created to merge `develop` into `main`.
--   **Release and Publish:** When a push is made to the `main` branch, a new GitHub Release is created with a tag corresponding to the version in `package.json`. This, in turn, triggers the `.github/workflows/publish.yml` workflow to publish the package to the npm registry.
+- **Build and Test:** On every push or pull request to the `main` and `develop` branches, the workflow in `.github/workflows/build.yml` is triggered. It installs dependencies, lints the code, builds the project, and runs the tests.
+- **Pull Request Creation:** If a build on the `develop` branch is successful, a pull request is automatically created to merge `develop` into `main`.
+- **Release and Publish:** When a push is made to the `main` branch, a new GitHub Release is created with a tag corresponding to the version in `package.json`. This, in turn, triggers the `.github/workflows/publish.yml` workflow to publish the package to the npm registry.
 
 ## Development
 

--- a/src/lib/commandExecutor.ts
+++ b/src/lib/commandExecutor.ts
@@ -22,7 +22,7 @@ import { promisify } from 'util';
 const execAsync = promisify(exec);
 
 // Centralized repository path.
-const REPO_PATH = '/home/kratos/Development/Github/The-Dave-Stack/mcp-backlog-md';
+const REPO_PATH = process.env.BACKLOG_REPO_PATH || process.cwd();
 
 /**
  * Executes a shell command and returns a standardized response object.
@@ -30,10 +30,7 @@ const REPO_PATH = '/home/kratos/Development/Github/The-Dave-Stack/mcp-backlog-md
  * @param successMessage The base message to return on success.
  * @returns A string containing the result of the command execution.
  */
-export async function executeCommand(
-  command: string,
-  successMessage: string
-): Promise<CallToolResult> {
+export async function executeCommand(command: string, successMessage: string): Promise<CallToolResult> {
   console.info({ command }, 'Executing command');
   try {
     const { stdout, stderr } = await execAsync(command, { cwd: REPO_PATH });
@@ -45,9 +42,7 @@ export async function executeCommand(
 
     console.info({ stdout }, 'Command executed successfully');
     return {
-      content: [
-        { type: 'text', text: `${stdout.trim()}`, _meta: { successMessage } },
-      ],
+      content: [{ type: 'text', text: `${stdout.trim()}`, _meta: { successMessage } }],
     };
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
This pull request makes the repository path configurable via the `BACKLOG_REPO_PATH` environment variable.

This addresses task-5.